### PR TITLE
Improve reports tab defaults and library filter

### DIFF
--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -25,11 +25,16 @@ async function findReports(directory: string): Promise<any[]> {
               allReports.push({
                 report_id: metadata.report_id,
                 title: `${metadata.company} – ${metadata.original_filename.replace(/\.(mp4|mp3|wav|m4a)$/i, '')}`,
+                client: metadata.company,
+                date: metadata.interviewDate || metadata.created_at,
                 type: "Individual Analysis", // Placeholder
                 status: "Complete", // Placeholder
                 generated: metadata.created_at,
                 dealsAnalyzed: 1, // Placeholder
-                insights: reportData.interview_structure?.flatMap((s:any) => s.questions || []).filter((q:any) => q && q.answer).length || 0,
+                insights:
+                  reportData.interview_structure
+                    ?.flatMap((s: any) => s.questions || [])
+                    .filter((q: any) => q && q.answer).length || 0,
               });
             }
           } catch (error) {


### PR DESCRIPTION
## Summary
- default to showing the Report Library tab
- expose client and date fields from the API
- add search, filter and sort controls to the Report Library
- show client and date for each report item

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint` *(fails: How would you like to configure ESLint?)*
- `pnpm run build` *(fails to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_b_684ff4fe3f588324a7646eccccda0a1b