### PR TITLE
Add View All option to global filter

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -86,11 +86,17 @@ export default function Navigation({
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Select value={selectedClient ?? undefined} onValueChange={setSelectedClient}>
+            <Select
+              value={selectedClient ?? "all"}
+              onValueChange={(v) =>
+                setSelectedClient(v === "all" ? null : v)
+              }
+            >
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Select client" />
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value="all">--View all--</SelectItem>
                 {clients.map((c) => (
                   <SelectItem key={c} value={c}>
                     {c}


### PR DESCRIPTION
## Summary
- add a "--View all--" option to the client filter in the navigation bar

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68503689fa788324b2d07ef70a99b93b